### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README Translations/README-en.md
+++ b/README Translations/README-en.md
@@ -25,7 +25,7 @@ The basic icon-pack is based on Numix-Circle-Icons, Faba and Arc.
 ### Installation:
 <p>
 <p>
-####You want to update your theme?
+#### You want to update your theme?
 _Only works if you already have the theme installed and didn't remove the project folder!_
 
 * Step 0: Update the repository:
@@ -38,7 +38,7 @@ git pull
 <br>
 <br>
 <br>
-####First Installation?
+#### First Installation?
 <br>
 _Install Git if you don't already have it installed._
 ```bash
@@ -68,7 +68,7 @@ gsettings set org.compiz.unityshell:/org/compiz/profiles/unity/plugins/unityshel
 ```
 <br>
 <br>
-####Restore?
+#### Restore?
 Didn't like? Do you want to reset theme to default?
 On project folder, run:
 ```bash
@@ -85,7 +85,7 @@ On project folder, run:
 #### Use your knowledge to help us!
 <br>
 <br>
-#####Help us translate this README for your language:
+##### Help us translate this README for your language:
 Create a file README-xx.md in path README-Translations.
 Translate this file.
 Submit your modifications for this repository.

--- a/README Translations/README-pt-BR.md
+++ b/README Translations/README-pt-BR.md
@@ -25,7 +25,7 @@ O pacote de icones é baseado no temas Numix-Circle-Icones, Faba e Arc
 ### Instalação:
 <p>
 <p>
-####Você quer atualizar o tema?
+#### Você quer atualizar o tema?
 _Funciona apenas se você já tem o tema instalado e não removeu a pasta do projeto!_
 
 * Passo 0: Atualizar o repositório:
@@ -38,7 +38,7 @@ git pull
 <br>
 <br>
 <br>
-####Primeira Instalação?
+#### Primeira Instalação?
 <br>
 _Instale o Git se você não já não tem ele instalado._
 ```bash
@@ -68,7 +68,7 @@ gsettings set org.compiz.unityshell:/org/compiz/profiles/unity/plugins/unityshel
 ```
 <br>
 <br>
-####Restaurar?
+#### Restaurar?
 Não curtiu? Quer resetar para o tema padrão?
 Abra na pasta do projeto e execute:
 ```bash
@@ -85,7 +85,7 @@ Abra na pasta do projeto e execute:
 #### Use o seu conhecimento para nos ajudar!
 <br>
 <br>
-#####Nos ajude traduzindo esse README para sua linguagem:
+##### Nos ajude traduzindo esse README para sua linguagem:
 Crie um arquivo README-xx.md na pasta README-Translations.
 Traduza esse arquivo.
 Submeta suas modificações para este repositório.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The basic icon-pack is based on Numix-Circle-Icons, Faba and Arc.
 ### Installation:
 <p>
 <p>
-####You want to update your theme?
+#### You want to update your theme?
 _Only works if you already have the theme installed and didn't remove the project folder!_
 
 * Step 0: Update the repository:
@@ -38,7 +38,7 @@ git pull
 <br>
 <br>
 <br>
-####First Installation?
+#### First Installation?
 <br>
 _Install Git if you don't already have it installed._
 ```bash
@@ -68,7 +68,7 @@ gsettings set org.compiz.unityshell:/org/compiz/profiles/unity/plugins/unityshel
 ```
 <br>
 <br>
-####Restore?
+#### Restore?
 Didn't like? Do you want to reset theme to default?
 On project folder, run:
 ```bash
@@ -84,7 +84,7 @@ On project folder, run:
 #### Use your knowledge to help us!
 <br>
 <br>
-#####Help us translate this README for your language:
+##### Help us translate this README for your language:
 Create a file README-xx.md in path README-Translations.
 Translate this file.
 Submit your modifications for this repository.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
